### PR TITLE
Fix Auth checking in setup

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -588,7 +588,7 @@ function! s:commands.setup(opts) abort
 
   let browser = copilot#Browser()
 
-  if empty(s:OAuthToken()) || empty(s:Auth()) || a:opts.bang
+  if empty(s:OAuthToken()) || a:opts.bang
     let response = copilot#HttpRequest('https://github.com/login/device/code', {
           \ 'method': 'POST',
           \ 'headers': {'Accept': 'application/json'},
@@ -604,7 +604,7 @@ function! s:commands.setup(opts) abort
         set mouse=
       endif
       if len(browser)
-        echo "Press ENTER to open GitHub your browser"
+        echo "Press ENTER to open GitHub in your browser"
         let c = getchar()
         while c isnot# 13 && c isnot# 10 && c isnot# 0
           let c = getchar()


### PR DESCRIPTION
removing last `s:Auth` call. (`s:Auth` was removed in version 1.0.4)

This caused a problem when running `:Copilot setup` if the terms were previously rejected

(I am aware that you're not accepting PRs atm, but this should be fixed in the future)