### PR TITLE
fix tab sending to the buffer when no suggestions

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -519,7 +519,7 @@ function! copilot#Accept(...) abort
     return repeat("\<Left>\<Del>", s.outdentSize) . repeat("\<Del>", s.deleteSize) .
             \ "\<C-R>\<C-O>=copilot#TextQueuedForInsertion()\<CR>"
   endif
-  let default = get(g:, 'copilot_tab_fallback', pumvisible() ? "\<C-N>" : "\t")
+  let default = get(g:, 'copilot_tab_fallback', pumvisible() ? "\<C-N>" : "\<Tab>")
   if !a:0
     return default
   elseif type(a:1) == v:t_string


### PR DESCRIPTION
# Context

In neovim, all time when Tab key is pressed (without copilot sugestions) it sends trash to the buffer like this:

![Copilot trash sended to the buffer](https://i.imgur.com/0bviS6i.png)
> `<Plug>(cmp.u.k.recursive: )`

# Objective

Try to send a simple tab and to fix that bug

At the moment we are not accepting contributions to the repository.
