### PR TITLE
call Schedule when OnCompleteChanged and not HideDuringCompletion

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -428,6 +428,8 @@ endfunction
 function! copilot#OnCompleteChanged() abort
   if s:HideDuringCompletion()
     return copilot#Clear()
+  else
+    return copilot#Schedule()
   endif
 endfunction
 


### PR DESCRIPTION
Thanks for your work related to https://github.com/github/copilot.vim/pull/11

It is a further enhancement. When OnCompleteChanged and s:HideDuringCompletion() is false, call `Schedule` so that users can get the latest copilot suggestion and avoid the conflict between old (unchanged) ghost text and new (changed) auto-completion text.