### PR TITLE
let user change the config root

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -18,10 +18,10 @@ else
 endif
 let s:config_root .= '/github-copilot'
 
-"\ if exists('g:copilot_config_root')
-"\     let s:config_root = g:copilot_config_root
+if exists('g:copilot_config_root')
+    let s:config_root = g:copilot_config_root
     " let user change the config root
-"\ endif
+endif
 
 if !isdirectory(s:config_root)
   call mkdir(s:config_root, 'p', 0700)

--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -17,6 +17,12 @@ else
   let s:config_root = expand('~/.config')
 endif
 let s:config_root .= '/github-copilot'
+
+"\ if exists('g:copilot_config_root')
+"\     let s:config_root = g:copilot_config_root
+    " let user change the config root
+"\ endif
+
 if !isdirectory(s:config_root)
   call mkdir(s:config_root, 'p', 0700)
 endif


### PR DESCRIPTION
let user change the config root.

It's common for users to share  their dotfile containing  `~/.config/ `.
And I find that `oauth_token` is stored at ~/.config/github-copilot/host.json