### PR TITLE
Compatible test: Vim 9.0.0105 also works

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Terms](https://docs.github.com/en/site-policy/github-terms/github-terms-for-addi
 
 ## Getting started
 
-1.  Install [Neovim][] or the latest patch of [Vim][] (9.0.0162 or newer).
+1.  Install [Neovim][] or the latest patch of [Vim][] (9.0.0105 or newer).
 
 2.  Install [Node.js][] version 16.  (Other versions should work too, except
     Node 18 which isn't supported yet.)

--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -6,7 +6,7 @@ let g:autoloaded_copilot = 1
 scriptencoding utf-8
 
 let s:has_nvim_ghost_text = has('nvim-0.6') && exists('*nvim_buf_get_mark')
-let s:has_vim_ghost_text = has('patch-9.0.0162') && has('textprop')
+let s:has_vim_ghost_text = has('patch-9.0.0105') && has('textprop')
 let s:has_ghost_text = s:has_nvim_ghost_text || s:has_vim_ghost_text
 
 let s:hlgroup = 'CopilotSuggestion'


### PR DESCRIPTION
Thanks for creating this useful repository, which helped me greatly!

Test Environment: Ubuntu 20.04.4 LTS

Currently, Ubuntu hasn't officially released the latest Vim yet, but users can install Vim 9.0.0105 version without compiling Vim themselves. So, loosing the version requirement could help more users to start using Copilot in Vim.