### PR TITLE
Fix multi-line virtual text preview

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -374,7 +374,7 @@ function! s:UpdatePreview() abort
     else
       call prop_add(line('.'), col('.'), {'type': s:hlgroup, 'text': text[0]})
       for line in text[1:]
-        call prop_add(line('.'), col('.'), {'type': s:hlgroup, 'text_align': 'below', 'text': line})
+        call prop_add(line('.'), 0, {'type': s:hlgroup, 'text_align': 'below', 'text': line})
       endfor
       if !empty(annot)
         call prop_add(line('.'), col('$'), {'type': s:annot_hlgroup, 'text': ' ' . annot[1][0]})


### PR DESCRIPTION
When `text_align` is present, the second parameter `col` should be set to `0`.

```vim
" :h prop_add
text_align    when "text" is present and {col} is zero;
                    specifies where to display the text:
	            after     after the end of the line
	            right     right aligned in the window (unless
			         the text wraps to the next screen
			         line)
		    below   in the next screen line
```