### PR TITLE
fix typo in LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 GitHub Copilot is offered under the [GitHub Terms of
-Service](hhttps://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot).
+Service](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot).
 
 Copyright (C) 2023 GitHub, Inc. - All Rights Reserved.


### PR DESCRIPTION
There's a typo in LICENSE.