### PR TITLE
do not autocomplete mails

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -131,6 +131,7 @@ endfunction
 let s:filetype_defaults = {
       \ 'yaml': 0,
       \ 'markdown': 0,
+      \ 'mail': 0,
       \ 'help': 0,
       \ 'gitcommit': 0,
       \ 'gitrebase': 0,


### PR DESCRIPTION
For people writing mails in mutt, this is a matter of privacy.
I was rather confused when I suddenly saw my mail getting autocompleted (badly).

Feel free to throw away my committer name and commit as yourself (as you apparently usually do), as long as this is changed upstream. :)