### PR TITLE
Fix kitty splits always opening in $HOME when using copilot.vim

### DIFF
--- a/lua/_copilot.lua
+++ b/lua/_copilot.lua
@@ -13,7 +13,7 @@ copilot.lsp_start_client = function(cmd, handler_names)
   end
   id = vim.lsp.start_client({
     cmd = cmd,
-    cmd_cwd = vim.fn.expand('%:p:h'),
+    cmd_cwd = vim.fn.getcwd(),
     name = 'copilot',
     handlers = handlers,
     get_language_id = function(bufnr, filetype)

--- a/lua/_copilot.lua
+++ b/lua/_copilot.lua
@@ -13,7 +13,7 @@ copilot.lsp_start_client = function(cmd, handler_names)
   end
   id = vim.lsp.start_client({
     cmd = cmd,
-    cmd_cwd = vim.fn.expand('~'),
+    cmd_cwd = vim.fn.expand('%:p:h'),
     name = 'copilot',
     handlers = handlers,
     get_language_id = function(bufnr, filetype)


### PR DESCRIPTION
I'm using [kitty](https://sw.kovidgoyal.net/kitty/) as my terminal emulator. Kitty has a feature to split a terminal window into smaller windows. Each split window is created in the same directory of where the split occur. If doing a split from `zsh` for example, it uses the current `$PWD`. When doing a split when running vim, it uses whatever `getcwd()` returns (or so I thought).

The moment I started using `copilot.vim`, all my splits were created in my home directory instead of the current directory. I tracked the issue to this LUA file, and updated the `cmd_cwd` to point to the current directory instead of `~`. This solves my issue, but obviously I have no idea of any side effect as I barely understand what the LUA file is doing. 

Hope that would at least work as a bug/regression report.