### PR TITLE
doc: fix setup documentation syntax

### DIFF
--- a/doc/copilot.txt
+++ b/doc/copilot.txt
@@ -106,7 +106,7 @@ copilot#Accept().  Here's an example with CTRL-J:
 <
 Lua version:
 >
-        vim.keymap.set('i', '<C-J>', 'copilot#Accept("\<CR>")', {
+        vim.keymap.set('i', '<C-J>', 'copilot#Accept(\"<CR>\")', {
           expr = true,
           replace_keycodes = false
         })


### PR DESCRIPTION
The documented setup script is not following lua syntax, this commit fixes that error

At the moment we are not accepting contributions to the repository.
