### PR TITLE
fix(plugin): show suggestions when using `a` to enter insert mode

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -400,10 +400,10 @@ endfunction
 
 function! s:Trigger(bufnr, timer) abort
   let timer = get(g:, '_copilot_timer', -1)
-  unlet! g:_copilot_timer
   if a:bufnr !=# bufnr('') || a:timer isnot# timer || mode() !=# 'i'
     return
   endif
+  unlet! g:_copilot_timer
   return copilot#Suggest()
 endfunction
 


### PR DESCRIPTION
fix(plugin): show suggestions when using `a` to enter insert mode

Summary:
Previously, when using `a` to enter insert mode, the suggestions would not show
up.

This is because when using `a` to enter insert mode, the cursor is placed after
the character under the cursor.  This would schedule _two_ timers, one for
`InsertEnter` and one for `CursorMovedI`.  The `InsertEnter` `#Schedule()`
happens first, and sets `g:_copilot_timer` to `N`.  The `CursorMovedI`
`#Schedule()` happens second, and sets `g:_copilot_timer` to `N+1`.  When the
`InsertEnter` timer `#Trigger()` fires, it checks the `g:_copilot_timer`
variable, and sees that it is not equal to `N`, and therefore **does not show
suggestions**.
**Crucially, it also unsets `g:_copilot_timer` variable.**
So when the `CursorMovedI` timer `#Trigger()` fires, `g:_copilot_timer` is not
set, and therefore **does not show suggestions** either!.

This commit fixes this by only unsetting `g:_copilot_timer` after the
suggestions are shown.


Test Plan:
1. Open a file
2. Type `i` to enter insert mode
3. Confirm that suggestions show up
4. Enter normal mode
5. Type `a` to enter insert mode
6. Confirm that suggestions show up
