### PR TITLE
fix E730: Using a List as a String in copilot#agent#New

### DIFF
--- a/autoload/copilot/agent.vim
+++ b/autoload/copilot/agent.vim
@@ -428,7 +428,7 @@ function! s:Command() abort
       return [v:null, node_version.string, 'Node.js version 18.x or newer required but found ' . node_version.string]
     endif
   endif
-  return [node + [agent, '--stdio'], node_version.string, warning]
+  return [node + agent + ['--stdio'], node_version.string, warning]
 endfunction
 
 function! s:UrlDecode(str) abort


### PR DESCRIPTION
![image](https://github.com/github/copilot.vim/assets/40995042/32c9df77-9e2d-4777-80bb-70ee2f33774e)

In version v1.19.0, function `copilot#agent#New` produces an error. The local variable `command`  in  `copilot#agent#New`  is actually  `['node', ['/home/jiangyinzuo/plugged/copilot.vim/dist/agent.js'], '--stdio']`, which leads to the occurrence of E730.

My node version is `v16.20.2` and my vim version is `9.1.113`.