### PR TITLE
use correct highlight in 88 color terminal

### DIFF
--- a/doc/copilot.txt
+++ b/doc/copilot.txt
@@ -181,5 +181,14 @@ after/colors/<colorschemename>.vim in your 'runtimepath' (e.g.,
 ~/.config/nvim/after/colors/solarized.vim).  Example declaration:
 >
         highlight CopilotSuggestion guifg=#555555 ctermfg=8
+
+If this fails, then add to your vimrc a corresponding autocommand for your
+color scheme (or all color schemes, as below): >
+>
+        augroup CopilotColorScheme
+        autocmd!
+        autocmd ColorScheme * highlight CopilotSuggestion guifg=#555555 ctermfg=8
+        autocmd VimEnter * silent doautocmd CopilotColorScheme ColorScheme *
+        augroup END
 <
  vim:tw=78:et:ft=help:norl:

--- a/plugin/copilot.vim
+++ b/plugin/copilot.vim
@@ -12,7 +12,7 @@ if v:version < 800 || !exists('##CompleteChanged')
 endif
 
 function! s:ColorScheme() abort
-  if &t_Co == 256
+  if &t_Co > 16
     hi def CopilotSuggestion guifg=#808080 ctermfg=244
   else
     hi def CopilotSuggestion guifg=#808080 ctermfg=8


### PR DESCRIPTION
An explicit check for &t_Co == 88 would be an option, but likely there are not many terminals covering proper ranges between 17 and 255 colors, so that the distinction by > 16 colors seems like the safer bet

At the moment we are not accepting contributions to the repository.
