### PR TITLE
Added docs for disabling <Tab> accept keymap due to current issues

### DIFF
--- a/doc/copilot.txt
+++ b/doc/copilot.txt
@@ -130,6 +130,10 @@ Lua version:
         })
         vim.g.copilot_no_tab_map = true
 <
+To disable the <Tab> accept keymap add this line (on the copilot setup/config):
+>
+        vim.keymap.del('i', '<Tab>')
+<
 The argument to copilot#Accept() is the fallback for when no suggestion is
 displayed.  In this example, a regular carriage return is used.  If no
 fallback is desired, use an argument of "" (an empty string).


### PR DESCRIPTION
- Currently there is an issue where ` vim.g.copilot_no_tab_map = true` or `vim.g.copilot_assume_mapped = true` don't disable the <Tab> accept mapping
- Disabling the mapping can be achieved by completely deleting the <Tab> keymap (in the copilot config/setup) via: `vim.keymap.del('i', '<Tab>')`
- Added this to official docs to avoid confusion of users and provide a solution until an official fix is available
