### PR TITLE
feat(repeat): fixes repeat command for Copilot completions

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -494,7 +494,7 @@ function! copilot#Accept(...) abort
     call s:ClearPreview()
     let s:suggestion_text = text
     return repeat("\<Left>\<Del>", s.outdentSize) . repeat("\<Del>", s.deleteSize) .
-            \ "\<C-R>\<C-O>=copilot#TextQueuedForInsertion()\<CR>" . (a:0 > 1 ? '' : "\<End>")
+            \ "\<C-R>\<C-R>=copilot#TextQueuedForInsertion()\<CR>" . (a:0 > 1 ? '' : "\<End>")
   endif
   let default = get(g:, 'copilot_tab_fallback', pumvisible() ? "\<C-N>" : "\t")
   if !a:0


### PR DESCRIPTION
This commit changes the key sequence in the Accept function from Control-R Control-O to Control-R Control-R. The change results in the `.` register being set when executed and thus allows the repeat command to chain Copilot completions.

See this [community discussion](https://github.com/orgs/community/discussions/113446) for further information.