### PR TITLE
Replacing deprecated start method for neovim

### DIFF
--- a/lua/_copilot.lua
+++ b/lua/_copilot.lua
@@ -28,7 +28,7 @@ copilot.lsp_start_client = function(cmd, handler_names, opts, settings)
   if #workspace_folders == 0 then
     workspace_folders = nil
   end
-  id = vim.lsp.start_client({
+  id = vim.lsp.start({
     cmd = cmd,
     cmd_cwd = vim.call('copilot#job#Cwd'),
     name = 'GitHub Copilot',


### PR DESCRIPTION
From neovim v0.11 the method `vim.lsp.start_client({` became deprecated, so this commit replaces it for `vim.lsp.start` which is the healthcheck suggestion.

```
- WARNING vim.lsp.start_client() is deprecated. Feature will be removed
in Nvim 0.13
  - ADVICE:
    - use vim.lsp.start() instead.
    - stack traceback:

/home/luizfilipe/.local/share/nvim/lazy/copilot.vim/lua/_copilot.lua:31
```

At the moment we are not accepting contributions to the repository.
