### PR TITLE
chore: use vim.lsp.start instead of vim.lsp.start_client

### DIFF
--- a/lua/_copilot.lua
+++ b/lua/_copilot.lua
@@ -28,7 +28,7 @@ copilot.lsp_start_client = function(cmd, handler_names, opts, settings)
   if #workspace_folders == 0 then
     workspace_folders = nil
   end
-  id = vim.lsp.start_client({
+  id = vim.lsp.start({
     cmd = cmd,
     cmd_cwd = vim.call('copilot#job#Cwd'),
     name = 'GitHub Copilot',


### PR DESCRIPTION

Summary: vim.lsp.start_client is deprecated in favor of vim.lsp.start. This
commit updates the code to use the new function.
