### PR TITLE
fix(vim.lsp): replace deprecated `vim.lsp.start_client` with `vim.lsp.start`

### DIFF
--- a/lua/_copilot.lua
+++ b/lua/_copilot.lua
@@ -31,7 +31,7 @@ copilot.lsp_start_client = function(cmd, handler_names, opts, settings)
   -- start_client() is deprecated, but the replacement start() breaks our
   -- restart workflow by returning the old client that's shutting down.
   -- https://github.com/neovim/neovim/issues/33616
-  id = vim.lsp.start_client({
+  id = vim.lsp.start({
     cmd = cmd,
     cmd_cwd = vim.call('copilot#job#Cwd'),
     name = 'GitHub Copilot',


### PR DESCRIPTION
The `vim.lsp.start_client` [is being deprecated](https://github.com/neovim/neovim/commit/e56437cd48f7df87ccdfb79812ee56241c0da0cb) in nvim 0.13.